### PR TITLE
ensure dest directory exists before writing files

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -17,8 +17,13 @@ const writeFile = (filepath, contents) => {
 	return Promise.resolve(true);
 }
 
+const ensureDir = dirPath => {
+	return Promise.resolve(true);
+}
+
 fsExtra.__setMockFiles = __setMockFiles;
 fsExtra.readFile = readFile;
 fsExtra.writeFile = writeFile;
+fsExtra.ensureDir = ensureDir;
 
 module.exports = fsExtra;

--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -6,6 +6,11 @@ const resolve = (dir, filepath) => {
 	return filepath;
 }
 
+const dirname = filePath => {
+	return 'dest';
+}
+
 path.resolve = resolve;
+path.dirname = dirname;
 
 module.exports = path;

--- a/index.js
+++ b/index.js
@@ -43,7 +43,10 @@ const processFile = (fileConfig, plugins) => {
 				to: destFilepath
 			})
 		)
-		.then(result => fs.writeFile(destFilepath, result.css));
+		.then(result => {
+			return fs.ensureDir(path.dirname(destFilepath))
+				.then(() => fs.writeFile(destFilepath, result.css));
+		});
 };
 
 module.exports = skeletorPluginPostCss = () => (

--- a/index.test.js
+++ b/index.test.js
@@ -157,6 +157,7 @@ test('run() processes one file with expected source CSS', () => {
 });
 
 test('run() writes one file to destination', () => {
+	const fsEnsureDirSpy = jest.spyOn(fs, 'ensureDir');
 	const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
 	
 	const config = {
@@ -168,12 +169,11 @@ test('run() writes one file to destination', () => {
 		]
 	}
 
-	expect.assertions(1);
+	expect.assertions(2);
 	return postCssPlugin().run(config, options)
 		.then(response => {
+			expect(fsEnsureDirSpy).toBeCalledWith('dest');
 			expect(fsWriteFileSpy).toBeCalledWith(destFilepath1, cssContent1);
-			fsWriteFileSpy.mockReset();
-  			fsWriteFileSpy.mockRestore();
 		});
 });
 
@@ -199,7 +199,5 @@ test('run() writes multiple files to destinations', () => {
 			expect(fsWriteFileSpy.mock.calls.length).toBe(2);
 			expect(fsWriteFileSpy.mock.calls[0]).toEqual([destFilepath1, cssContent1]);
 			expect(fsWriteFileSpy.mock.calls[1]).toEqual([destFilepath2, cssContent2]);
-			fsWriteFileSpy.mockReset();
-  			fsWriteFileSpy.mockRestore();
 		});
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-postcss",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "A PostCSS Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The plugin was erroring out if the destination directory did not already exist when it was attempting to write the processed CSS file