### PR TITLE
display postcss warnings

### DIFF
--- a/__mocks__/postcss.js
+++ b/__mocks__/postcss.js
@@ -1,21 +1,36 @@
 'use strict';
 
 const postcss = jest.genMockFromModule('postcss');
-
+let warningsArr = [];
 let shouldThrowProcessError = false;
+
+const warnings = () => warningsArr;
 
 const process = (css, opts) => {
 	if(shouldThrowProcessError) {
 		throw new Error('error');
 	}
 	return Promise.resolve({
-		css: css
+		css,
+		warnings
 	});
 }
 
 postcss.__setThrowProcessError = value => {
 	shouldThrowProcessError = value;
 };
+
+postcss.__setWarnings = messages => {
+	warningsArr = messages.map(message => ({
+		type: 'warning',
+		text: message
+	}));
+}
+
+postcss.__reset = () => {
+	shouldThrowProcessError = false;
+	warningsArr = [];
+}
 
 postcss.mockReturnValue({
 	process

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const run = (config, {logger}) => {
 		});
 	}
 
-	const promises = config.files.map(fileConfig => processFile(fileConfig, config.plugins));
+	const promises = config.files.map(fileConfig => processFile(fileConfig, config.plugins, logger));
 
 	return Promise.all(promises)
 		.then(() => {
@@ -32,7 +32,7 @@ const run = (config, {logger}) => {
 
 };
 
-const processFile = (fileConfig, plugins) => {
+const processFile = (fileConfig, plugins, logger) => {
 	const srcFilepath = path.resolve(process.cwd(), fileConfig.src);
 	const destFilepath = path.resolve(process.cwd(), fileConfig.dest);
 
@@ -44,10 +44,16 @@ const processFile = (fileConfig, plugins) => {
 			})
 		)
 		.then(result => {
+			displayWarnings(result, logger);
 			return fs.ensureDir(path.dirname(destFilepath))
 				.then(() => fs.writeFile(destFilepath, result.css));
 		});
 };
+
+const displayWarnings = (result, logger) => {
+	const warnings = result.warnings();
+	warnings.forEach(warning => logger.warn(`${warning.type}: ${warning.text}`));
+}
 
 module.exports = skeletorPluginPostCss = () => (
 	{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-postcss",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A PostCSS Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
PostCSS returns an array of warnings that encounters while processing CSS files. These warnings now get displayed in the console. This should help with debugging syntax errors in CSS files.